### PR TITLE
first implementation of context - toolbar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,17 +5,21 @@ import NavBar from "./components/NavBar";
 import ToolBar from "./components/ToolBar";
 import DragDrop from "./components/DragDrop";
 import "./App.css";
+import {PassivesContext} from "./context/Contexts";
+import {networkElement} from "./data/passives";
 
 function App() {
   return (
     <>
+      <NavBar />
       <DndProvider backend={HTML5Backend}>
-        <NavBar />
-        <ToolBar />
-        <section>
-          <h1>Arrastre los elementos del Armado</h1>
-          <DragDrop />
-        </section>
+        <PassivesContext.Provider value={networkElement} >
+          <ToolBar />
+          <section>
+            <h1>Arrastre los elementos del Armado</h1>
+            <DragDrop />
+          </section>
+        </PassivesContext.Provider>
       </DndProvider>
       <Footer />
     </>

--- a/src/components/ToolBar.jsx
+++ b/src/components/ToolBar.jsx
@@ -1,12 +1,15 @@
 import styles from "./ToolBar.module.css";
-import { networkElement } from "../data/passives";
 import Model from "./Model";
-
-const modelList = networkElement.map(({ id, type }) => {
-  return <Model key={`key${id}`} id={id} type={type} />;
-});
+import { useContext } from "react";
+import { PassivesContext } from "../context/Contexts";
 
 function ToolBar() {
+  
+  const networkElements = useContext(PassivesContext);
+  const modelList = networkElements.map(({ id, type }) => {
+    return <Model key={`key${id}`} id={id} type={type} />;
+  });
+
   return (
     <>
       <div className={styles.bar}>{modelList}</div>

--- a/src/context/Contexts.js
+++ b/src/context/Contexts.js
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const PassivesContext = createContext([]);


### PR DESCRIPTION
documentation about Context and implementations.
[react-documentation](https://react.dev/reference/react/createContext#provider)

as you can see now we are using something like 2 providers 1 from dnd library and the other one is our `PassivesContext`

please let me know add the other implementation in this same Branch on `DragDrop` component. You should replace the `import { networkElement } from "../data/passives";` by the new implementation!

this will be little bit cleaner for us avoing the import of the same file passives around the other components.

let me know your feedback 

Thanks